### PR TITLE
Added viscous model

### DIFF
--- a/src/ConstitutiveModels/ConstitutiveModels.jl
+++ b/src/ConstitutiveModels/ConstitutiveModels.jl
@@ -220,8 +220,8 @@ include("./ViscousModels.jl")
 
 function (obj::ViscousIncompressible)(strategy::DerivativeStrategy{T}, Δt::Float64) where T
   Ψe, Se, ∂Se∂Ce          = obj.ShortTerm(strategy, StressTensor{:SecondPiola}())
-  ∂Ψ∂F(∇u, ∇un, state)    = Piola(obj, Se, ∂Se∂Ce, ∇u, ∇un, Δt, state)
-  ∂Ψ∂F∂F(∇u, ∇un, state)  = Tangent(obj, Se, ∂Se∂Ce, ∇u, ∇un, Δt, state)
+  ∂Ψ∂F(∇u, ∇un, state)    = Piola(obj, Δt, Se, ∂Se∂Ce, ∇u, ∇un, state)
+  ∂Ψ∂F∂F(∇u, ∇un, state)  = Tangent(obj, Δt, Se, ∂Se∂Ce, ∇u, ∇un, state)
   return Ψe, ∂Ψ∂F, ∂Ψ∂F∂F
 end
 

--- a/src/ConstitutiveModels/ViscousModels.jl
+++ b/src/ConstitutiveModels/ViscousModels.jl
@@ -164,18 +164,18 @@ Tangent operator of Ce for the incompressible case
 # Arguments
 - `::ViscousIncompressible` The viscous model
 - `γα`: Characteristic time τα / (τα + Δt)
-- `∂Se_∂Ce_`: Function of C
+- `∂Se∂Ce_`: Function of C
 - ...
 
 # Return
 - `∂Ce∂C`
 """
-function ∂Ce_∂C(::ViscousIncompressible, γα, ∂Se_∂Ce_, invUvn, Ce, Ce_trial, λα, F)
+function ∂Ce_∂C(::ViscousIncompressible, γα, ∂Se∂Ce_, invUvn, Ce, Ce_trial, λα, F)
     C = F' * F
     G = cof(C)
     Ge = cof(Ce)
-    ∂Se∂Ce = ∂Se_∂Ce_(Ce)
-    ∂Se∂Ce_trial = ∂Se_∂Ce_(Ce_trial)
+    ∂Se∂Ce = ∂Se∂Ce_(Ce)
+    ∂Se∂Ce_trial = ∂Se∂Ce_(Ce_trial)
     ∂Ce_trial_∂C = Outer_13_24(invUvn, invUvn)
     #------------------------------------------
     # Derivative of return mapping with respect to Ce and λα

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -27,6 +27,13 @@ end
 @publish ConstitutiveModels ElectroMech
 @publish ConstitutiveModels ThermoElectroMech
 @publish ConstitutiveModels ThermoMech
+@publish ConstitutiveModels Visco
+@publish ConstitutiveModels ViscoElastic
+@publish ConstitutiveModels ViscousIncompressible
+@publish ConstitutiveModels GeneralizedMaxwell
+@publish ConstitutiveModels IsochoricNeoHookean3D
+@publish ConstitutiveModels initializeStateVariables
+@publish ConstitutiveModels updateStateVariables!
 
 @publish WeakForms CouplingStrategy
 @publish WeakForms residual_EM

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -31,7 +31,7 @@ end
 @publish ConstitutiveModels ViscoElastic
 @publish ConstitutiveModels ViscousIncompressible
 @publish ConstitutiveModels GeneralizedMaxwell
-@publish ConstitutiveModels IsochoricNeoHookean3D
+@publish ConstitutiveModels IncompressibleNeoHookean3D
 @publish ConstitutiveModels initializeStateVariables
 @publish ConstitutiveModels updateStateVariables!
 

--- a/src/TensorAlgebra/TensorAlgebra.jl
+++ b/src/TensorAlgebra/TensorAlgebra.jl
@@ -761,7 +761,7 @@ end
 
 Compose a 3x3 matrix from its eigenvalues and eigenvectors
 """
-@inline function EigDecomposition(λ::SVector,n::SMatrix)
+@inline function EigDecomposition(λ::SVector{3},n::SMatrix{3,3})
   SMatrix{3,3}(λ[1]*n[1:3]*n[1:3]' + λ[2]*n[4:6]*n[4:6]' + λ[3]*n[7:9]*n[7:9]')
 end
 
@@ -777,9 +777,9 @@ Compute the square root of a 3x3 matrix by means of eigen decomposition.
 # Returns
 - `::SMatrix`: the squared root matrix
 """
-@inline function sqrtM(A::SMatrix)
+@inline function sqrtM(A::SMatrix{3,3})
   λ, Q = eigen(A)
-  EigDecomposition(λ, Q)
+  EigDecomposition(sqrt.(λ), Q)
 end
 
 

--- a/src/TensorAlgebra/TensorAlgebra.jl
+++ b/src/TensorAlgebra/TensorAlgebra.jl
@@ -16,8 +16,8 @@ export (⊗₁²³)
 export (⊗₁₃²⁴)
 export (⊗₁₂³⁴)
 export (⊗₁²)
-export sqrtM
-export Cofactor
+export msqrt
+export cof
 export Cross_I4_A
 export I3
 export I9
@@ -767,7 +767,7 @@ end
 
 
 """
-  sqrtM(A::SMatrix)::SMatrix
+  msqrt(A::SMatrix)::SMatrix
 
 Compute the square root of a 3x3 matrix by means of eigen decomposition.
 
@@ -777,14 +777,14 @@ Compute the square root of a 3x3 matrix by means of eigen decomposition.
 # Returns
 - `::SMatrix`: the squared root matrix
 """
-@inline function sqrtM(A::SMatrix{3,3})
+@inline function msqrt(A::SMatrix{3,3})
   λ, Q = eigen(A)
   EigDecomposition(sqrt.(λ), Q)
 end
 
 
 """
-  Cofactor(A::SMatrix)::SMatrix
+  cof(A::SMatrix)::SMatrix
 
 Calculate the cofactor of a matrix.
 
@@ -794,7 +794,7 @@ Calculate the cofactor of a matrix.
 # Returns
 - `SMatrix`: the cofactor matrix.
 """
-@inline function Cofactor(A::SMatrix)
+@inline function cof(A::SMatrix)
  return det(A)*inv(A')
 end
 

--- a/src/TensorAlgebra/TensorAlgebra.jl
+++ b/src/TensorAlgebra/TensorAlgebra.jl
@@ -29,6 +29,8 @@ export Contraction_IP_JPKL
 export Contraction_IP_PJKL
 export I3_
 export I9_
+export SI3
+export SI9
 
 # outer ⊗ \otimes
 # inner ⊙ \odot
@@ -487,6 +489,10 @@ function (×ᵢ⁴)(A::TensorValue{3,3,Float64})
     0.0, 0.0, 0.0, A[5], -A[4], 0.0, -A[2], A[1], 0.0, 0.0, 0.0, 0.0)
 end
 
+function (×ᵢ⁴)(A::SMatrix)
+  get_array(×ᵢ⁴(TensorValue(A)))
+end
+
 
 function Gridap.TensorValues.cross(A::TensorValue{3,3,Float64}, B::TensorValue{3,3,Float64})
 
@@ -756,6 +762,9 @@ end
 
 const I3_ = TensorValue(Matrix(1.0I, 3, 3))
 const I9_ = TensorValue(Matrix(1.0I, 9, 9))
+
+const SI3 = SMatrix{3,3}(1.0I)
+const SI9 = SMatrix{9,9}(1.0I)
 
 function I3() 
   TensorValue(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)

--- a/src/TensorAlgebra/TensorAlgebra.jl
+++ b/src/TensorAlgebra/TensorAlgebra.jl
@@ -28,6 +28,7 @@ export Outer_14_23
 export Contraction_IP_JPKL
 export Contraction_IP_PJKL
 export I3_
+export I9_
 
 # outer ⊗ \otimes
 # inner ⊙ \odot
@@ -459,8 +460,25 @@ function (⊗₁₃²⁴)(A::TensorValue{3,3,Float64}, B::TensorValue{3,3,Float6
   A[9]*B[9])
 end
 
-function (×ᵢ⁴)(A::TensorValue{3,3,Float64})
+"""
+    ×ᵢ⁴(A::TensorValue{3,3,Float64}) -> TensorValue{4,3,Float64}
 
+Fourth-order tensor cross product operator.
+Constructs a 4th-order antisymmetric-like tensor from a second-order tensor `A` 
+(3×3 matrix), used for double contractions.
+
+This operator implements a mapping that enables consistent evaluation of terms like:
+`∂Ψ/∂J * ×ᵢ⁴(F)` in hyperelastic models, where `×ᵢ⁴` acts as a specialized 
+tensor product for assembling fourth-order stiffness contributions from skew-symmetric operators.
+
+# Arguments
+- `A::TensorValue{3,3,Float64}`: A 3×3 second-order tensor, passed as a flat TensorValue.
+
+# Returns
+- `TensorValue{9,9,Float64}`: A 4th-order tensor stored in flattened form (81 components), 
+  containing antisymmetric combinations of `A` components.
+"""
+function (×ᵢ⁴)(A::TensorValue{3,3,Float64})
   TensorValue(0.0, 0.0, 0.0, 0.0, A[9], -A[8], 0.0, -A[6], A[5], 0.0, 0.0, 0.0, -A[9],
     0.0, A[7], A[6], 0.0, -A[4], 0.0, 0.0, 0.0, A[8], -A[7], 0.0, -A[5], A[4], 0.0, 0.0, -A[9],
     A[8], 0.0, 0.0, 0.0, 0.0, A[3], -A[2], A[9], 0.0, -A[7], 0.0, 0.0, 0.0, -A[3], 0.0,
@@ -736,8 +754,8 @@ end
   Meta.parse("TensorValue{D,D, Float64}($str)")
 end
 
-const I3_ = diagm(vec(ones(3,1)))
-const I9_ = diagm(vec(ones(9,1)))
+const I3_ = TensorValue(Matrix(1.0I, 3, 3))
+const I9_ = TensorValue(Matrix(1.0I, 9, 9))
 
 function I3() 
   TensorValue(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)


### PR DESCRIPTION
FYI @jmartfrut @RogelioOrtigosa @mbarillasvelasquez 

**Changelog**
- `ConstitutiveModels.jl`: Added new abstract classes for constitutive models and adder wrappers for viscous models
- `ViscousModels.jl` [new file]: Implementation of derivatives for viscous models
- `TensorAlgebra.jl`: Added the required methods for the viscous models. You'll see that the names of some functions are slightliy different from the code was provided to me
- `Exports.jl`: Added required exports

**Notes**
I'll apply the analyitical derivatives for the incompressible neo-Hookean in a latter PR. Same with the tests for the derivatives, I don't wnat to mix too many changes in the same PR.

**Validation**
I've compared the current implementation against an example that was given to me some weeks ago. It consists on a cantilever (0.5m long, 0.1m thick) with a point load. The results are exactly the same with both implementations (same iterations, same residual).
<img width="1500" height="500" alt="image" src="https://github.com/user-attachments/assets/70c594bc-a175-4f3a-aa09-8e55206b7899" />

**TODO**
- Add analytical derivatives
- Add test for analytical derivatives
- Add benchmark from the paper (Zeng et al. 2025)